### PR TITLE
Tilt needs more time to move successfully so added check for Tilt axis

### DIFF
--- a/PTZDevice.cs
+++ b/PTZDevice.cs
@@ -107,7 +107,7 @@ namespace PTZ
                instData, Marshal.SizeOf(control.Instance), controlData, Marshal.SizeOf(control));
 
             //TODO: It's a DC motor, no better way?
-            Thread.Sleep(20);
+            Thread.Sleep(axis == KSProperties.CameraControlFeature.KSPROPERTY_CAMERACONTROL_TILT_RELATIVE ? 50 : 20); // Tilt needs longer to move
 
             control.Instance.Value = 0; //STOP!
             control.Instance.Flags = (int)CameraControlFlags.Relative;


### PR DESCRIPTION
Did some experimenting with my new Logitec BCC950 Webcam, and got it working except Tilt up and down did not seem to work. 

Figured out that Tilt needs longer in the sleep to successfully move camera up and down so added a check for Tilt with a longer Sleep 
Didn't fix the // TODO: to work out a better way for DC motor. Hey it works, right?


Just realised there is an issue for Tilt not working. #1 This PR fixes that issue.